### PR TITLE
Add more tags

### DIFF
--- a/ckanext/govtypes/plugin.py
+++ b/ckanext/govtypes/plugin.py
@@ -17,7 +17,7 @@ def create_gov_types():
         logging.info("Creating vocab 'gov_types'")
         data = {'name': 'gov_types'}
         vocab = tk.get_action('vocabulary_create')(context, data)
-        for tag in (u'Federal', u'Estatal', u'Municipal', u'Autónomo'):
+        for tag in (u'Federal', u'Estatal', u'Municipal', u'Autonomo'):
             logging.info(
                     "Adding tag {0} to vocab 'gov_types'".format(tag))
             data = {'name': tag, 'vocabulary_id': vocab['id']}

--- a/ckanext/govtypes/plugin.py
+++ b/ckanext/govtypes/plugin.py
@@ -17,7 +17,7 @@ def create_gov_types():
         logging.info("Creating vocab 'gov_types'")
         data = {'name': 'gov_types'}
         vocab = tk.get_action('vocabulary_create')(context, data)
-        for tag in (u'Federal', u'Estatal', u'Municipal'):
+        for tag in (u'Federal', u'Estatal', u'Municipal', u'Autónomo'):
             logging.info(
                     "Adding tag {0} to vocab 'gov_types'".format(tag))
             data = {'name': tag, 'vocabulary_id': vocab['id']}

--- a/ckanext/govtypes/templates/snippets/gov_level.html
+++ b/ckanext/govtypes/templates/snippets/gov_level.html
@@ -5,5 +5,6 @@
 <li class="nav-item"><a href="/dataset?q=Federal">Federal</a></li>
 <li class="nav-item"><a href="/dataset?q=Estatal">Estatal</a></li>
 <li class="nav-item"><a href="/dataset?q=Municipal">Municipal</a></li>
+<li class="nav-item"><a href="/dataset?q=Autonomo">Autonomo</a></li>
 </ul>
 </section>


### PR DESCRIPTION
HOWTO TEST:

1) Levantar una instancia de CKAN con DataCats e instalar este plugin según la documentación
http://docs.datacats.com/quickstart.html  (agregar gov_type a la lista de plugins en development.ini)

2) Si ya se tiene una versión anterior del diccionario actualizarlo usando [ckanapi](https://github.com/ckan/ckanapi) con la IP del ambiente local y las credenciales del usuario en datacats

```
import ckanapi
remote = ckanapi.RemoteCKAN(CKAN_HOST, user_agent='ckanops/1.0', apikey=CKAN_API_TOKEN)
remote.action.vocabulary_list()
remote.action.vocabulary_update(id='id_del_vocabulario', name='Autonomo')
```

Nota: si no has usado antes pip para instalar paquetes de Python, revisa esta [referencia](https://pip.pypa.io/en/stable/installing/)